### PR TITLE
Add support for SetPosition, Position and other mpris properties

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2015 dodo.the.last@gmail.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/applet.lua
+++ b/applet.lua
@@ -129,6 +129,7 @@ function Properties:getters(interface, props)
         local property = { type = opts.type }
         if opts.write then property.write = self:setter(opts.write) end
         if opts.read  then property.read  = self:getter(opts.read, name, interface) end
+        if opts.callback then property.read = opts.callback end
         properties[name] = property
     end
     return properties
@@ -170,7 +171,7 @@ function Applet:init(opts)
         next          = true,
         pause         = true,
         play          = true,
-        seek          = false,
+        seek          = true,
         tracklist     = false,
         fullscreen    = false,
         setfullscreen = false,
@@ -225,6 +226,7 @@ function Applet:init(opts)
             MinimumRate = { type = 'd', read = {'minrate'} },
             MaximumRate = { type = 'd', read = {'maxrate'} },
             Rate = { type = 'd', read = {'rate'}, write = 'rate' },
+            Position = { type = 'x', callback = backcall(opts, 'position') },
         }),
     })
 end

--- a/mpris-scm-0.rockspec
+++ b/mpris-scm-0.rockspec
@@ -7,7 +7,7 @@ description = {
     homepage = "https://github.com/dodo/lua-mpris",
     license = "MIT",
 }
-dependencies = { "lua >= 5.1", "lua-dbus >= scm-0", "lfs" }
+dependencies = { "lua >= 5.1", "lua-dbus >= scm-0" }
 build = {
    type = "builtin",
     modules = {

--- a/mpris-scm-0.rockspec
+++ b/mpris-scm-0.rockspec
@@ -7,7 +7,7 @@ description = {
     homepage = "https://github.com/dodo/lua-mpris",
     license = "MIT",
 }
-dependencies = { "lua >= 5.1", "lua-dbus >= scm-0" }
+dependencies = { "lua >= 5.1", "lua-dbus >= scm-0", "lfs" }
 build = {
    type = "builtin",
     modules = {

--- a/mpv.lua
+++ b/mpv.lua
@@ -125,8 +125,10 @@ local function update_idle(name, idle)
 end
 
 local function table_contains(table, item)
-    for key, value in pairs(table) do
-        if value == item then return key end
+    if table then
+        for key, value in pairs(table) do
+            if value == item then return key end
+        end
     end
     return false
 end

--- a/mpv.lua
+++ b/mpv.lua
@@ -149,6 +149,8 @@ local function update_title(name, title)
     end
 
     meta['mpris:trackid'] = '/org/mpv/Track/123456'
+    meta['mpris:artUrl'] = nil
+    meta['xesam:url'] = nil
     path = mp.get_property('path')
     if path or path ~= '' then
         cwd = mputils.getcwd()

--- a/mpv.lua
+++ b/mpv.lua
@@ -6,7 +6,7 @@ for path in package.path:gmatch(";([^;]+)") do
 end
 
 local Applet = require("mpris.applet")
-require("lfs")
+local mputils = require 'mp.utils'
 
 local pid = tostring(mp):match(': (%w+)$') -- FIXME
 local mpris = Applet:new({ name = "mpv", id = 'instance' .. pid })
@@ -140,9 +140,10 @@ local function update_title(name, title)
     meta['mpris:trackid'] = '/org/mpv/Track/123456'
     path = mp.get_property('path')
     if path or path ~= '' then
-        cwd = lfs.currentdir()
-        meta['mpris:artUrl'] = cwd..'/'..string.match(path, "(.-)([^\\/]-%.?([^%.\\/]*))$")..'/cover.jpg'
-        meta['xesam:url'] = cwd..'/'..path
+        cwd = mputils.getcwd()
+        local dir, fname = mputils.split_path(path)
+        meta['mpris:artUrl'] = mputils.join_path(mputils.join_path(cwd, dir), 'cover.jpg')
+        meta['xesam:url'] = mputils.join_path(cwd, path)
     end
     mpris.property:set('metadata', meta)
 end

--- a/mpv.lua
+++ b/mpv.lua
@@ -5,7 +5,7 @@ for path in package.path:gmatch(";([^;]+)") do
     end
 end
 
-local Applet = require("mpris.applet")
+local Applet = require("lua-mpris.applet")
 local mputils = require 'mp.utils'
 
 local pid = tostring(mp):match(': (%w+)$') -- FIXME

--- a/mpv.lua
+++ b/mpv.lua
@@ -7,22 +7,22 @@ end
 
 
 local valid_utf8_sequences = { {{0,127}},
-                          {{194,223}, {128,191}},
-                          {     224 , {160,191}, {128,191}},
-                          {{225,236}, {128,191}, {128,191}},
-                          {     237 , {128,159}, {128,191}},
-                          {{238,239}, {128,191}, {128,191}},
-                          {     240 , {144,191}, {128,191}, {128,191}},
-                          {{241,243}, {128,191}, {128,191}, {128,191}},
-                          {     244 , {128,143}, {128,191}, {128,191}}
-                        }
+                               {{194,223}, {128,191}},
+                               {     224 , {160,191}, {128,191}},
+                               {{225,236}, {128,191}, {128,191}},
+                               {     237 , {128,159}, {128,191}},
+                               {{238,239}, {128,191}, {128,191}},
+                               {     240 , {144,191}, {128,191}, {128,191}},
+                               {{241,243}, {128,191}, {128,191}, {128,191}},
+                               {     244 , {128,143}, {128,191}, {128,191}}
+                             }
 
 -- Returns the length (in bytes) of the character at (byte) position i of
 -- the string str . Returns -1 if there's an invalid character at position i.
 function utf8_char_length(str, i)
     local len = string.len(str)
 
-    for k, sequence in pairs(valid_sequences) do
+    for k, sequence in pairs(valid_utf8_sequences) do
         if i + #sequence - 1 > len then
             return -1
         end
@@ -56,7 +56,7 @@ function remove_invalid_utf8_chars(str)
 
     while i <= len do
         local seq = {}
-        local char_length = char_length(str, i)
+        local char_length = utf8_char_length(str, i)
         if char_length > 0 then
             i = i + char_length
         else


### PR DESCRIPTION
Added support for callbacks when getting values so there's no need
to keep a variable updated and so we can provide the current media
position throught mpris' Position property

Added support for SetPosition so mpris clients can seek freely.

Fix media length reporting (which was always nil) by getting the
mpris:length value from the duration property.

Fill values for the following metadata:
xesam:album
xesam:albumArtist
xesam:artist
xesam:trackNumber
xesam:genre
xesam:lyricist
xesam:discNumber
mpris:trackid
mpris:artUrl
xesam:url

Note that mpris:trackid has a fixed value (it needs to be a dbus
object reference). This value is later provided by the mpris client
as the first parameter of SetPosition.

Also, in order to find out the full path of the url, we need to find
out the current working directory, which requires to add lfs as a
dependency. Maybe there's another way to find out the CWD but I
don't know so much lua. Also, to show the artUrl, a 'cover.jpg'
file has to be available in the same directory as the media. The ideal
solution would be to extract the cover from the music file, but again,
that's beyond my lua knowledge.

This makes KDE Plasma mediacontroller completely usable to control
mpv.